### PR TITLE
Fix #7 and #8: Split FileViewSeafilePlugin::actions() in to versionControlActions()

### DIFF
--- a/plugin/fileviewseafileplugin.cpp
+++ b/plugin/fileviewseafileplugin.cpp
@@ -74,8 +74,13 @@ KVersionControlPlugin::ItemVersion FileViewSeafilePlugin::itemVersion(const KFil
 		return UnversionedVersion;
 	}
 }
+QList<QAction *> FileViewSeafilePlugin::versionControlActions(const KFileItemList &items) const
+{
+	Q_UNUSED(items)
+	return {};
+}
 
-QList<QAction *> FileViewSeafilePlugin::actions(const KFileItemList &items) const
+QList<QAction *> FileViewSeafilePlugin::outOfVersionControlActions(const KFileItemList &items) const
 {
 //	//test if this it's actually seafile
 //	try {

--- a/plugin/fileviewseafileplugin.h
+++ b/plugin/fileviewseafileplugin.h
@@ -17,7 +17,8 @@ public:
 	bool beginRetrieval(const QString &directory) override;
 	void endRetrieval() override;
 	ItemVersion itemVersion(const KFileItem &item) const override;
-	QList<QAction *> actions(const KFileItemList &items) const override;
+	QList<QAction *> versionControlActions(const KFileItemList &items) const override;
+	QList<QAction *> outOfVersionControlActions(const KFileItemList &items) const override;
 
 private:
 	SeafStatus *_seaf;


### PR DESCRIPTION
…  …and outOfVersionControlAction() to be work with latest KVersionControlPlugin

Fixes #7 and #8.
Tested on latest Arch Linux.